### PR TITLE
fix(rails): restart command able to ignore restart sync stack

### DIFF
--- a/lib/devbin/commands/rails.rb
+++ b/lib/devbin/commands/rails.rb
@@ -17,6 +17,8 @@ module Devbin
         desc: "Display usage information"
       method_option :detach, aliases: "-d", type: :boolean, required: false, default: false,
         desc: "Start the server with detached mode"
+      method_option :sync, aliases: "-s", type: :boolean, default: true,
+        desc: "Start the docker-sync also"
       def server(app_name)
         if options[:help]
           invoke :help, ["server"]
@@ -53,8 +55,10 @@ module Devbin
       desc "stop APP_NAME", "Stop the rails application"
       method_option :help, aliases: "-h", type: :boolean,
         desc: "Display usage information"
-      method_option :all, aliases: "-a", type: :boolean, required: false, default: false,
+      method_option :all, aliases: "-a", type: :boolean, default: false,
         desc: "Stop all applications"
+      method_option :sync, aliases: "-s", type: :boolean, default: true,
+        desc: "Stop the docker-sync also"
       def stop(app_name = "")
         if options[:help]
           invoke :help, ["stop"]
@@ -64,11 +68,13 @@ module Devbin
         end
       end
 
-      desc "restart APP_NAME", "Restart docker-sync stack and the application"
+      desc "restart APP_NAME", "Restart the application"
       method_option :help, aliases: "-h", type: :boolean,
         desc: "Display usage information"
-      method_option :detach, aliases: "-d", type: :boolean, required: false, default: false,
+      method_option :detach, aliases: "-d", type: :boolean, default: false,
         desc: "Restart the server with detached mode"
+      method_option :sync, aliases: "-s", type: :boolean, default: false,
+        desc: "Restart the docker-sync also"
       def restart(app_name)
         if options[:help]
           invoke :help, ["restart"]

--- a/lib/devbin/commands/rails/restart.rb
+++ b/lib/devbin/commands/rails/restart.rb
@@ -8,15 +8,21 @@ module Devbin
       class Restart < Devbin::Command
         def initialize(app_name, options)
           @app_name = app_name
-          @options = options
+          @options = options || {}
         end
 
         def execute(input: $stdin, output: $stdout)
           require_relative "stop"
-          Devbin::Commands::Rails::Stop.new(@app_name, {all: false}).execute
-          run "docker-sync start", chdir: docker_sync_pwd
+          Devbin::Commands::Rails::Stop.new(
+            @app_name,
+            {all: false, sync: @options[:sync]}
+          ).execute
+
           require_relative "server"
-          Devbin::Commands::Rails::Server.new(@app_name, {detach: @optons && @options[:detach]}).execute
+          Devbin::Commands::Rails::Server.new(
+            @app_name,
+            @options.slice(:detach, :sync)
+          ).execute
           output.puts "OK"
         end
       end

--- a/lib/devbin/commands/rails/server.rb
+++ b/lib/devbin/commands/rails/server.rb
@@ -13,11 +13,13 @@ module Devbin
 
         def execute(input: $stdin, output: $stdout)
           require "tty-command"
-          begin
-            run "docker-sync start", chdir: docker_sync_pwd
-          rescue TTY::Command::ExitError => e
-            unless e.message =~ /warning\s+docker-sync\salready\sstarted\sfor\sthis\sconfiguration/
-              raise e
+          if @options[:sync]
+            begin
+              run "docker-sync start", chdir: docker_sync_pwd
+            rescue TTY::Command::ExitError => e
+              unless e.message =~ /warning\s+docker-sync\salready\sstarted\sfor\sthis\sconfiguration/
+                raise e
+              end
             end
           end
           run "docker-compose up -d #{@app_name}", chdir: docker_pwd

--- a/lib/devbin/commands/rails/stop.rb
+++ b/lib/devbin/commands/rails/stop.rb
@@ -12,7 +12,9 @@ module Devbin
         end
 
         def execute(input: $stdin, output: $stdout)
-          run "docker-sync stop", chdir: docker_sync_pwd
+          if @options[:sync]
+            run "docker-sync stop", chdir: docker_sync_pwd
+          end
           if @options[:all]
             run "docker-compose stop", chdir: docker_pwd
           else


### PR DESCRIPTION
TODO: separate `docker-sync` to a new namespace